### PR TITLE
fix(base_route): perform cleanup if auth cookie expires

### DIFF
--- a/ssr/src/component/base_route.rs
+++ b/ssr/src/component/base_route.rs
@@ -6,7 +6,7 @@ use leptos_router::*;
 use leptos_use::use_cookie;
 
 use crate::auth::delegate_identity;
-use crate::consts::{USER_CANISTER_ID_STORE, USER_PRINCIPAL_STORE};
+use crate::consts::{ACCOUNT_CONNECTED_STORE, USER_CANISTER_ID_STORE, USER_PRINCIPAL_STORE};
 use crate::utils::ParentResource;
 use crate::{
     auth::{
@@ -37,6 +37,7 @@ fn CtxProvider(temp_identity: Option<JwkEcKey>, children: ChildrenFn) -> impl In
     let canisters_store = create_rw_signal(None::<Canisters<true>>);
     provide_context(canisters_store);
 
+    let new_identity_issued = temp_identity.is_some();
     let temp_identity_c = temp_identity.clone();
     create_local_resource(
         || (),
@@ -65,6 +66,20 @@ fn CtxProvider(temp_identity: Option<JwkEcKey>, children: ChildrenFn) -> impl In
             return;
         }
         set_referrer_store(referrer_principal.get_untracked())
+    });
+
+    // We need to perform this cleanup in case the user's cookie expired
+    let (_, set_logged_in, _) =
+        use_local_storage::<bool, FromToStringCodec>(ACCOUNT_CONNECTED_STORE);
+    let (_, set_user_canister_id, _) =
+        use_local_storage::<Option<Principal>, JsonSerdeCodec>(USER_CANISTER_ID_STORE);
+    let (_, set_user_principal) = use_cookie::<Principal, FromToStringCodec>(USER_PRINCIPAL_STORE);
+    create_effect(move |_| {
+        if new_identity_issued {
+            set_logged_in(false);
+            set_user_canister_id(None);
+            set_user_principal(None);
+        }
     });
 
     let canisters_res: AuthCansResource = ParentResource(create_resource(
@@ -101,19 +116,12 @@ fn CtxProvider(temp_identity: Option<JwkEcKey>, children: ChildrenFn) -> impl In
                     .map(|res| {
                         let cans_wire = try_or_redirect!(res);
                         let cans = try_or_redirect!(cans_wire.canisters());
-                        let (_, set_user_canister_id, _) = use_local_storage::<
-                            Option<Principal>,
-                            JsonSerdeCodec,
-                        >(USER_CANISTER_ID_STORE);
+                        let user_canister = cans.user_canister();
                         let user_principal = cans.user_principal();
                         create_effect(move |_| {
-                            let (_, set_user_principal) = use_cookie::<
-                                Principal,
-                                FromToStringCodec,
-                            >(USER_PRINCIPAL_STORE);
-                            set_user_principal.set(Some(user_principal));
+                            set_user_canister_id(Some(user_canister));
+                            set_user_principal(Some(user_principal));
                         });
-                        set_user_canister_id(Some(cans.user_canister()));
                         canisters_store.set(Some(cans));
                     })
             }}


### PR DESCRIPTION
Handles an edge case where the user performs google login.
after a while and their auth cookie expires
If the user's cookie expires, the auth server function returns a new anonymous identity,
but since `ACCOUNT_CONNECTED_STORE` is already set, the app thinks the user is still logged in