### PR TITLE
test: load the video from storj instead of cloudflare

### DIFF
--- a/ssr/src/utils/mod.rs
+++ b/ssr/src/utils/mod.rs
@@ -108,7 +108,8 @@ pub fn stream_url(uid: impl Display) -> String {
 }
 
 pub fn mp4_url(uid: impl Display) -> String {
-    format!("{CF_STREAM_BASE}/{uid}/downloads/default.mp4")
+    // dont worry about the key in the url below, it will be destroyed automatically in a couple days
+    format!("https://link.storjshare.io/raw/jv43kl3kcxrap5srqqbapeuhqo4a/test-bucket/{uid}.mp4")
 }
 
 #[cfg(all(feature = "ga4", feature = "ssr"))]


### PR DESCRIPTION
Switches the video retrieval from cloudflare to trial account's storj bucket. All the videos that are seeded by [backend](https://github.com/yral-dapp/hot-or-not-backend-canister/blob/main/scripts/canisters/docker/uid_list) are loaded into my storj bucket.

For now, to try it out:
- switch to `test/storj-backed-feed`
- keep backend image locally
- `./local-run.sh`
---

I can barely feel the difference, but I welcome everyone to give it a shot at least once.

I also ran some simple bench marks to get some numbers:
```
Average download speed reported by curl for downloading 102 files with a size
range of ~[500kb, 10mb]


Storj ====================================
	Mean: 2.07316e+06 bytes/s
	Median: 1695713.5 bytes/s
	Standard Deviation: 1426472.75 bytes/s

Cloudflare ===============================
	Mean: 4.72868e+06 bytes/s
	Median: 3750166 bytes/s
	Standard Deviation: 3376576.21 bytes/s

Cloudflare is 2x faster than storj
```
But it barely makes a difference in practice.